### PR TITLE
PoC test: assert on array length

### DIFF
--- a/consumer/src/api.pact.spec.ts
+++ b/consumer/src/api.pact.spec.ts
@@ -12,7 +12,7 @@ const mockProvider = new Pact({
   logLevel: 'info',
 });
 
-const mockVisitorsResponse = Matchers.like({
+const mock1VisitorResponse = Matchers.like({
   results: Matchers.arrayContaining({
     isNewInPeriod: Matchers.boolean(true),
     currentVisits: Matchers.number(15),
@@ -26,6 +26,42 @@ const mockVisitorsResponse = Matchers.like({
   success: Matchers.boolean(true),
 });
 
+const mock3VisitorsResponse = Matchers.like({
+  results: Matchers.arrayContaining(
+    {
+      isNewInPeriod: Matchers.boolean(true),
+      currentVisits: Matchers.number(15),
+      previousVisits: Matchers.number(2),
+      daysActive: Matchers.number(4),
+      fullName: Matchers.string('Test One'),
+      userName: Matchers.string('test.one'),
+      userId: Matchers.string('11111-11111-11111-11111-11111'),
+      isDisabledUser: Matchers.boolean(false),
+    },
+    {
+      isNewInPeriod: Matchers.boolean(true),
+      currentVisits: Matchers.number(15),
+      previousVisits: Matchers.number(2),
+      daysActive: Matchers.number(4),
+      fullName: Matchers.string('Test Two'),
+      userName: Matchers.string('test.two'),
+      userId: Matchers.string('22222-22222-22222-22222-22222'),
+      isDisabledUser: Matchers.boolean(false),
+    },
+    {
+      isNewInPeriod: Matchers.boolean(true),
+      currentVisits: Matchers.number(15),
+      previousVisits: Matchers.number(2),
+      daysActive: Matchers.number(4),
+      fullName: Matchers.string('Test Three'),
+      userName: Matchers.string('test.three'),
+      userId: Matchers.string('33333-33333-33333-33333-33333'),
+      isDisabledUser: Matchers.boolean(false),
+    },
+  ),
+  success: Matchers.boolean(true),
+});
+
 const mockNoVisitorsResponse = Matchers.like({
   results: Matchers.arrayContaining(),
   success: Matchers.boolean(true),
@@ -33,7 +69,7 @@ const mockNoVisitorsResponse = Matchers.like({
 
 describe('API Pact test', () => {
   describe('retrieving visitors', () => {
-    test('visitors exists', async () => {
+    test('1 visitor exists', async () => {
       /**
        * ARRANGE
        *
@@ -42,7 +78,7 @@ describe('API Pact test', () => {
        * as explicit and lengthy as possible.
        */
       await mockProvider
-        .given('visitors exist')
+        .given('1 visitor exists')
         .uponReceiving('a request to get visitors')
         .withRequest({
           method: 'GET',
@@ -51,7 +87,7 @@ describe('API Pact test', () => {
         .willRespondWith({
           status: 200,
           headers: { 'Content-Type': 'application/json; charset=utf-8' },
-          body: mockVisitorsResponse,
+          body: mock1VisitorResponse,
         });
 
       return mockProvider.executeTest(async (mockServer) => {
@@ -80,6 +116,83 @@ describe('API Pact test', () => {
               fullName: 'Christopher Weibel',
               userName: 'christopher.weibel',
               userId: '5e3c90f5-048d-413b-bffb-0cb3bd44423d',
+              isDisabledUser: false,
+            },
+          ],
+          success: true,
+        });
+        return;
+      });
+    });
+    test('3 visitors exists', async () => {
+      /**
+       * ARRANGE
+       *
+       * These lines below tells Pact to set the whole scenario up.
+       * This will produce the Pact documentation so we want to be
+       * as explicit and lengthy as possible.
+       */
+      await mockProvider
+        .given('3 visitors exist')
+        .uponReceiving('a request to get visitors')
+        .withRequest({
+          method: 'GET',
+          path: '/visitors',
+        })
+        .willRespondWith({
+          status: 200,
+          headers: { 'Content-Type': 'application/json; charset=utf-8' },
+          body: mock3VisitorsResponse,
+        });
+
+      return mockProvider.executeTest(async (mockServer) => {
+        /**
+         * ACT
+         * The Pact mock provider is used to mock out the actual provider,
+         * meaning that integration-like tests can be run without
+         * requiring the actual service provider to be available.
+         * We tell the API client to talk to the Pact mock server instead
+         * of the real thing. Thus, in summary we mock the response that
+         * comes from the API so that we can unit test it.
+         */
+        const API = new APIGateway(mockServer.url);
+        const visitors = await API.getVisitors();
+
+        /**
+         * ASSERT
+         *
+         * We assert the mocked response the and expected response match.
+         */
+        expect(visitors).toEqual({
+          results: [
+            {
+              isNewInPeriod: true,
+              currentVisits: 15,
+              previousVisits: 2,
+              daysActive: 4,
+              fullName: 'Test One',
+              userName: 'test.one',
+              userId: '11111-11111-11111-11111-11111',
+              isDisabledUser: false,
+            },
+            {
+              isNewInPeriod: true,
+              currentVisits: 15,
+              previousVisits: 2,
+              daysActive: 4,
+              fullName: 'Test Two',
+              userName: 'test.two',
+              userId: '22222-22222-22222-22222-22222',
+              isDisabledUser: false,
+            },
+            {
+              isNewInPeriod: true,
+              currentVisits: 15,
+              previousVisits: 2,
+              daysActive: 4,
+              fullName: 'Test Three',
+              userName: 'test.three',
+              userId: '33333-33333-33333-33333-33333',
               isDisabledUser: false,
             },
           ],

--- a/provider/src/controllers/visitors.pact.test.ts
+++ b/provider/src/controllers/visitors.pact.test.ts
@@ -23,13 +23,17 @@ describe('Pact Verification', () => {
       consumerVersionSelectors: [
         { consumer: 'Usage Analytics Frontend', branch: 'main' },
       ],
-      // pactUrls: [path.resolve(__dirname, '../../../consumer/pacts')],
-      pactBrokerUrl: process.env.PACT_BROKER_BASE_URL || 'invalid_url',
-      pactBrokerToken: process.env.PACT_BROKER_TOKEN || 'invalid_token',
+      pactUrls: [path.resolve(__dirname, '../../../consumer/pacts')],
+      // pactBrokerUrl: process.env.PACT_BROKER_BASE_URL || 'invalid_url',
+      // pactBrokerToken: process.env.PACT_BROKER_TOKEN || 'invalid_token',
       stateHandlers: {
-        'visitors exist': async () => {
+        '1 visitor exists': async () => {
           setEmptyVisitorsDB(false);
-          Promise.resolve('Visitors in db');
+          Promise.resolve('2 Visitors in db');
+        },
+        '3 visitors exist': async () => {
+          setEmptyVisitorsDB(false);
+          Promise.resolve('2 Visitors in db');
         },
         'no visitors': async () => {
           setEmptyVisitorsDB(true);


### PR DESCRIPTION
**Summary**
This is a PoC to demonstrate that Pact should not be used to assert on the number of items. In our contract tests we do type matching because `we don't care what the exact value is returned at a particular path is, we just care that a value is present and that it is of the expected type.`

**References:**
- https://docs.pact.io/implementation_guides/ruby/matching#type-matching
- https://docs.pact.io/faq#why-is-there-no-support-for-specifying-optional-attributes
- https://docs.pact.io/implementation_guides/ruby/matching#flexible-length-arrays